### PR TITLE
Fix vfs_read unknown symbol on kernel 4.15+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ EXTRA_CFLAGS += -Wno-unused-function
 EXTRA_CFLAGS += -Wno-unused
 #EXTRA_CFLAGS += -Wno-uninitialized
 EXTRA_CFLAGS += -Wno-incompatible-pointer-types
+#EXTRA_CFLAGS += -Wno-error=date-time
 
 GCC_VER_49 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 4.9 | bc )
 ifeq ($(GCC_VER_49),1)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ https://github.com/diederikdehaas/rtl8812AU \
 https://github.com/ulli-kroll/rtl8821au \
 https://github.com/Grawp/rtl8812au_rtl8821au
 
+## Build on Raspberry pi 4
+```bash
+make ARCH=arm
+```
+
+If date-time errors appear, you can uncomment the following line in the CMAKE:
+
+```c
+#EXTRA_CFLAGS += -Wno-error=date-time
+```
 
 ## License
 GPLv2 as supplied by the manufacturer

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4493,7 +4493,11 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 	source = rtw_zmalloc(2048);
 
 	if (source != NULL) {
-		len = vfs_read(fp, source, len, &pos);
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+			len = kernel_read(fp, source, len, &pos);
+		#else
+			len = vfs_read(fp, source, len, &pos);
+		#endif
 		rtw_parse_cipher_list(nlo_info, source);
 		rtw_mfree(source, 2048);
 	}

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1988,7 +1988,11 @@ static int readFile(struct file *fp, char *buf, int len)
 
 	while (sum < len) {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0))
+		rlen = kernel_read(fp, buf + sum, len - sum, &fp->f_pos);
+	#else
 		rlen = __vfs_read(fp, buf + sum, len - sum, &fp->f_pos);
+	#endif
 #else
 		rlen = fp->f_op->read(fp, buf + sum, len - sum, &fp->f_pos);
 #endif


### PR DESCRIPTION
The driver was not working for the Raspberry 4 with kernel:  4.19.75-v7l
**dmesg** shows the error:  **vfs_read unknown symbol**  because **vfs_read** was deprecated.
This PR fixes that issue by using **kernel_read**. 